### PR TITLE
Fix #14 and exceptions during inverter sleep when smart meter not installed

### DIFF
--- a/custom_components/solplanet/__init__.py
+++ b/custom_components/solplanet/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .client import SolplanetApi, SolplanetClient
 from .const import (
@@ -89,6 +90,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolplanetConfigEntry) ->
             manufacturer=meter_info.manufactory,
             model=meter_info.name,
         )
+
+    if len(coordinator.data[INVERTER_IDENTIFIER]) == 0:
+        raise ConfigEntryNotReady(f"No device detected, inverter in sleep mode")
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/solplanet/coordinator.py
+++ b/custom_components/solplanet/coordinator.py
@@ -51,7 +51,7 @@ class SolplanetDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
             meter = None
-            meter_sn = isns[0]
+            meter_sn = isns[0] if len(isns) > 1 else None
             try:
                 meter_data = await self.__api.get_meter_data()
                 meter_info = await self.__api.get_meter_info()
@@ -83,7 +83,7 @@ class SolplanetDataUpdateCoordinator(DataUpdateCoordinator):
                     }
                     for i in range(len(battery_isns))
                 },
-                METER_IDENTIFIER: {meter_sn: meter} if meter else {},
+                METER_IDENTIFIER: {meter_sn: meter} if meter and meter_sn else {},
             }
 
         except Exception as err:

--- a/custom_components/solplanet/coordinator.py
+++ b/custom_components/solplanet/coordinator.py
@@ -51,7 +51,7 @@ class SolplanetDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
             meter = None
-            meter_sn = isns[0] if len(isns) > 1 else None
+            meter_sn = isns[0] if len(isns) > 0 else None
             try:
                 meter_data = await self.__api.get_meter_data()
                 meter_info = await self.__api.get_meter_info()

--- a/custom_components/solplanet/sensor.py
+++ b/custom_components/solplanet/sensor.py
@@ -100,7 +100,9 @@ class SolplanetSensor(CoordinatorEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         # Set the native value here so we can use it in available property
         # without having to recalculate it
-        self._attr_native_value = self._get_value_from_coordinator()
+        data = self._get_value_from_coordinator()
+        if data:
+            self._attr_native_value = data
         super()._handle_coordinator_update()
 
     def _get_value_from_coordinator(self) -> float | int | str | None:

--- a/custom_components/solplanet/sensor.py
+++ b/custom_components/solplanet/sensor.py
@@ -102,9 +102,13 @@ class SolplanetSensor(CoordinatorEntity, SensorEntity):
 
     def _get_value_from_coordinator(self) -> float | int | str | None:
         """Return the state of the sensor."""
-        data = self.coordinator.data[self.entity_description.data_field_device_type][
-            self._isn
-        ][self.entity_description.data_field_data_type]
+        try:
+            data = self.coordinator.data[self.entity_description.data_field_device_type][
+                self._isn
+            ][self.entity_description.data_field_data_type]
+        except KeyError:
+            _LOGGER.debug("Component serial number not in data. This is normal if the inverter is sleeping.")
+            return None
 
         for path_item in self.entity_description.data_field_path:
             if isinstance(data, list) or hasattr(data, "__dict__"):

--- a/custom_components/solplanet/sensor.py
+++ b/custom_components/solplanet/sensor.py
@@ -4,6 +4,7 @@ from collections import abc
 from dataclasses import dataclass
 import re
 from typing import Any
+import logging
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -51,6 +52,8 @@ from .const import (
     METER_IDENTIFIER,
 )
 from .coordinator import SolplanetDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
Fixing #14 by raising ConfigEntryNotReady when no data is provided by the inverter. This way it keeps trying to initialize until data is provided and sensors can be confirgured.

Also fixing the below exception and the sensor unavailability during the inverter sleep: 

```2024-12-04 20:28:01.995 DEBUG (MainThread) [custom_components.solplanet.coordinator] list index out of range
Traceback (most recent call last):
  File "/config/custom_components/solplanet/coordinator.py", line 54, in _async_update_data
    meter_sn = isns[0]
               ~~~~^^^
IndexError: list index out of range
Stack (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 223, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 209, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 189, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 674, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 641, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1990, in _run_once
    handle._run()
  File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 266, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 382, in _async_refresh
    self.data = await self._async_update_data()
  File "/config/custom_components/solplanet/coordinator.py", line 79, in _async_update_data
    _LOGGER.debug(err, stack_info=True, exc_info=True) ```