### PR TITLE
Use API calls to manage the charge/discharge schedule

### DIFF
--- a/custom_components/solplanet/__init__.py
+++ b/custom_components/solplanet/__init__.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -24,6 +26,7 @@ from .const import (
 )
 from .coordinator import SolplanetDataUpdateCoordinator
 from .services import async_setup_services
+from .modbus import DataType
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -34,9 +37,60 @@ PLATFORMS: list[Platform] = [
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 _LOGGER = logging.getLogger(__name__)
 
-type SolplanetConfigEntry = ConfigEntry[SolplanetApi]  # noqa: F821
+type SolplanetConfigEntry = ConfigEntry[SolplanetApi]
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_WRITE_REGISTER = "modbus_write_single_holding_register"
+SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_address"): cv.positive_int,
+        vol.Required("register_address"): cv.positive_int,
+        vol.Required("data_type"): vol.In(
+            ["B16", "B32", "S16", "U16", "S32", "U32", "E16"]
+        ),
+        vol.Required("value"): vol.Coerce(int),
+        vol.Required("dry_run"): cv.boolean,
+    }
+)
+
+
+def setup_hass_services(hass: HomeAssistant, api: SolplanetApi) -> None:
+    """Set up Solplanet services."""
+
+    async def handle_write_modbus_register(call: ServiceCall) -> None:
+        device_address = call.data["device_address"]
+        register_address = call.data["register_address"]
+        value = call.data["value"]
+        data_type_str = call.data["data_type"]
+        dry_run = call.data["dry_run"]
+
+        data_type_map = {
+            "B16": DataType.B16,
+            "B32": DataType.B32,
+            "S16": DataType.S16,
+            "U16": DataType.U16,
+            "S32": DataType.S32,
+            "U32": DataType.U32,
+            "E16": DataType.E16,
+            "String": DataType.STRING,
+        }
+        data_type = data_type_map.get(data_type_str, DataType.S16)
+
+        await api.modbus_write_single_holding_register(
+            data_type=data_type,
+            device_address=device_address,
+            register_address=register_address,
+            value=value,
+            dry_run=dry_run,
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_WRITE_REGISTER,
+        handle_write_modbus_register,
+        schema=SERVICE_WRITE_REGISTER_SCHEMA,
+    )
 
 
 async def async_setup(hass: HomeAssistant, entry: SolplanetConfigEntry) -> bool:
@@ -82,7 +136,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolplanetConfigEntry) ->
 
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, f"{BATTERY_IDENTIFIER}_{battery_info.isn or ""}")},
+            identifiers={(DOMAIN, f"{BATTERY_IDENTIFIER}_{battery_info.isn or ''}")},
             name=f"Battery ({battery_info.isn})",
             serial_number=battery_info.isn,
             sw_version=battery_info.battery.softwarever if battery_info.battery else "",
@@ -94,7 +148,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolplanetConfigEntry) ->
 
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, f"{METER_IDENTIFIER}_{meter_isn or ""}")},
+            identifiers={(DOMAIN, f"{METER_IDENTIFIER}_{meter_isn or ''}")},
             name="Energy meter",
             serial_number=meter_info.sn,
             manufacturer=meter_info.manufactory,
@@ -105,6 +159,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolplanetConfigEntry) ->
         raise ConfigEntryNotReady("No device detected, inverter in sleep mode")
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    setup_hass_services(hass, api)
 
     return True
 

--- a/custom_components/solplanet/__init__.py
+++ b/custom_components/solplanet/__init__.py
@@ -23,8 +23,14 @@ from .const import (
     METER_IDENTIFIER,
 )
 from .coordinator import SolplanetDataUpdateCoordinator
+from .services import async_setup_services
 
-PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.BINARY_SENSOR,
+]
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,8 +41,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, entry: SolplanetConfigEntry) -> bool:
     """Set up the Solplanet integration."""
-
     hass.data.setdefault(DOMAIN, {})
+    
+    # Set up services
+    await async_setup_services(hass)
+    
     return True
 
 

--- a/custom_components/solplanet/binary_sensor.py
+++ b/custom_components/solplanet/binary_sensor.py
@@ -1,0 +1,95 @@
+"""Solplanet binary sensor platform."""
+from dataclasses import dataclass
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SolplanetConfigEntry
+from .client import BatterySchedule
+from .const import BATTERY_IDENTIFIER, DOMAIN
+from .entity import SolplanetEntity, SolplanetEntityDescription
+
+_LOGGER = logging.getLogger(__name__)
+
+@dataclass(frozen=True, kw_only=True)
+class SolplanetBinarySensorEntityDescription(
+    SolplanetEntityDescription, BinarySensorEntityDescription
+):
+    """Describe Solplanet binary sensor entity."""
+
+
+class SolplanetBinarySensor(SolplanetEntity, BinarySensorEntity):
+    """Representation of a Solplanet binary sensor."""
+
+    entity_description: SolplanetBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        description: SolplanetBinarySensorEntityDescription,
+        isn: str,
+        coordinator,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(description=description, isn=isn, coordinator=coordinator)
+        self._attr_is_on = None  # Initialize the binary sensor state
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        return self._get_value_from_coordinator()
+
+
+def create_battery_binary_sensors(coordinator, isn: str) -> list[SolplanetBinarySensorEntityDescription]:
+    """Create binary sensors for battery."""
+    def value_mapper(raw):
+        has_schedule = any(
+            any(code != 0 for code in raw.get(day, []))
+            for day in BatterySchedule.DAYS
+            if day in raw
+        )
+        return has_schedule
+
+    return [
+        SolplanetBinarySensorEntityDescription(
+            key=f"{isn}_schedule_active",
+            name="Schedule Active",
+            data_field_device_type=BATTERY_IDENTIFIER,
+            data_field_data_type="schedule",
+            data_field_path=["raw"],
+            data_field_value_mapper=value_mapper,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            attributes_fn=lambda schedule: {
+                "raw_schedule": schedule["raw"],
+                "formatted_schedule": {
+                    day: [slot.human_readable() for slot in day_slots]
+                    for day, day_slots in schedule["slots"].items()
+                },
+                "pin": schedule["Pin"],
+                "pout": schedule["Pout"]
+            }
+        ),
+    ]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SolplanetConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up binary sensors."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    sensors = []
+    for isn in coordinator.data[BATTERY_IDENTIFIER]:
+        sensors.extend(
+            SolplanetBinarySensor(description=description, isn=isn, coordinator=coordinator)
+            for description in create_battery_binary_sensors(coordinator, isn)
+        )
+
+    async_add_entities([sensor for sensor in sensors if sensor.has_value_in_response()])

--- a/custom_components/solplanet/binary_sensor.py
+++ b/custom_components/solplanet/binary_sensor.py
@@ -57,8 +57,8 @@ def create_battery_binary_sensors(coordinator, isn: str) -> list[SolplanetBinary
 
     return [
         SolplanetBinarySensorEntityDescription(
-            key=f"{isn}_schedule_active",
-            name="Schedule Active",
+            key=f"{isn}_schedule_configured",
+            name="Schedule Configured",
             data_field_device_type=BATTERY_IDENTIFIER,
             data_field_data_type="schedule",
             data_field_path=["raw"],

--- a/custom_components/solplanet/client.py
+++ b/custom_components/solplanet/client.py
@@ -812,9 +812,9 @@ class SolplanetApi:
 
     async def set_schedule_power(self, pin: int | None = None, pout: int | None = None) -> None:
         """Set battery schedule power configuration."""
-        _LOGGER.debug("Setting battery schedule power - pin: %s, pout: %s", pin, pout)
         current = await self.get_schedule()
-        schedule = BatterySchedule.encode_schedule({},   # Changed method name and use empty slots
+        schedule = BatterySchedule.encode_schedule(
+            current["slots"],
             pin=pin if pin is not None else current["Pin"],
             pout=pout if pout is not None else current["Pout"])
         request = SetScheduleRequest(value=schedule)
@@ -822,17 +822,21 @@ class SolplanetApi:
 
     async def set_schedule_pin(self, pin: int) -> None:
         """Set battery schedule pin configuration."""
-        _LOGGER.debug("Setting battery schedule pin: %s", pin)
         current = await self.get_schedule()
-        schedule = BatterySchedule.encode_schedule({}, pin=pin, pout=current["Pout"])  # Changed method
+        schedule = BatterySchedule.encode_schedule(
+            current["slots"],
+            pin=pin, 
+            pout=current["Pout"])
         request = SetScheduleRequest(value=schedule)
         await self.client.post("setting.cgi", request)
 
     async def set_schedule_pout(self, pout: int) -> None:
         """Set battery schedule pout configuration."""
-        _LOGGER.debug("Setting battery schedule pout: %s", pout)
         current = await self.get_schedule()
-        schedule = BatterySchedule.encode_schedule({}, pin=current["Pin"], pout=pout)  # Changed method
+        schedule = BatterySchedule.encode_schedule(
+            current["slots"],
+            pin=current["Pin"], 
+            pout=pout)
         request = SetScheduleRequest(value=schedule)
         await self.client.post("setting.cgi", request)
 

--- a/custom_components/solplanet/client.py
+++ b/custom_components/solplanet/client.py
@@ -643,7 +643,7 @@ class BatterySchedule:
     def encode_schedule(slots: dict[str, list[ScheduleSlot]], pin: int = 5000, pout: int = 5000) -> dict:
         """Encode slots into raw schedule."""
         # Validate slots for each day
-        for day, day_slots in slots.items():
+        for day_slots in slots.values():
             if day_slots:  # Only validate if there are slots
                 ScheduleSlot.validate_slots(day_slots)
                 

--- a/custom_components/solplanet/client.py
+++ b/custom_components/solplanet/client.py
@@ -810,14 +810,6 @@ class SolplanetApi:
             "Pout": raw_response.get("Pout", 5000)
         }
 
-    async def set_schedule_slots(self, slots: dict[str, list[ScheduleSlot]]) -> None:
-        """Set battery schedule slots configuration."""
-        _LOGGER.debug("Setting battery schedule slots: %s", slots)
-        current = await self.get_schedule()
-        schedule = BatterySchedule.encode_schedule(slots)  # Changed from create_slots_schedule
-        request = SetScheduleRequest(value=schedule)
-        await self.client.post("setting.cgi", request)
-
     async def set_schedule_power(self, pin: int | None = None, pout: int | None = None) -> None:
         """Set battery schedule power configuration."""
         _LOGGER.debug("Setting battery schedule power - pin: %s, pout: %s", pin, pout)

--- a/custom_components/solplanet/client.py
+++ b/custom_components/solplanet/client.py
@@ -5,9 +5,12 @@ from dataclasses import dataclass
 from inspect import signature
 import json
 import logging
+import time
 from typing import Any
 
 from aiohttp import ClientResponse, ClientSession
+
+from .modbus import DataType, ModbusRtuFrameGenerator
 
 __author__ = "Zbigniew Motyka"
 __copyright__ = "Zbigniew Motyka"
@@ -20,44 +23,32 @@ _LOGGER = logging.getLogger(__name__)
 class GetInverterDataResponse:
     """Get inverter data response model.
 
-    Attributes
-    ----------
-    flg : int
-        TBD ??
-    tim : str
-        Datetime in format YYYYMMDDHHMMSS
-    tmp : int
-        Inverter temperature [C]
-    fac : int
-        AC frequency [Hz]
-    pac : int
-        AC real power [W]
-    sac : int
-        AC apparent power [VA]
-    qac : int
-        AC reactive / complex power [VAR]
-    eto : int
-        Energy produced total [kWh]
-    etd : int
-        Energy produced today [kWh]
-    hto : int
-        Total running time [h]
-    pf : int
-        Power factor
-    wan : int
-        TBD ??
-    err : int
-        Error
-    vac : list[int]
-        AC voltages [V]
-    iac : list[int]
-        AC current [A]
-    vpv : list[int]
-        DC voltages [V]
-    ipv : list[int]
-        DC current [A]
-    str : list[int]
-        TBD ??
+    Attributes:
+        flg: Inverter status code
+        tim: Timestamp of data
+        tmp: Inverter temperature in 0.1°C
+        fac: AC frequency in 0.01 Hz
+        pac: Total active power output in W
+        sac: Total apparent power in VA
+        qac: Total reactive power in VAr
+        eto: Total energy production in 0.1 kWh # codespell:ignore eto
+        etd: Today's energy production in 0.1 kWh
+        hto: Total working hours in h
+        pf: Power factor in 0.01
+        wan: Warning code
+        err: Error code
+        vac: AC phase voltages in 0.1 V
+        iac: AC phase currents in 0.1 A
+        vpv: PV input voltages per MPPT in 0.1 V
+        ipv: PV input currents per MPPT in 0.01 A
+        str: String values
+        stu: Status value
+        pac1: Phase 1 active power in W
+        qac1: Phase 1 reactive power in VAr
+        pac2: Phase 2 active power in W
+        qac2: Phase 2 reactive power in VAr
+        pac3: Phase 3 active power in W
+        qac3: Phase 3 reactive power in VAr
 
     """
 
@@ -68,7 +59,7 @@ class GetInverterDataResponse:
     pac: int | None = None
     sac: int | None = None
     qac: int | None = None
-    eto: int | None = None
+    eto: int | None = None  # codespell:ignore eto
     etd: int | None = None
     hto: int | None = None
     pf: int | None = None
@@ -90,7 +81,25 @@ class GetInverterDataResponse:
 
 @dataclass
 class GetInverterInfoItemResponse:
-    """Get inverter info item response."""
+    """Get inverter info item response.
+
+    Attributes:
+        isn: Inverter serial number
+        add: Address value
+        safety: Safety code
+        rate: Rate value
+        msw: Main software version
+        ssw: Slave software version
+        tsw: Third software version
+        pac: Current power output in W
+        etd: Today's energy production in 0.1 kWh
+        eto: Total energy production in 0.1 kWh # codespell:ignore eto
+        err: Error code
+        cmv: Communication version
+        mty: Device model type code
+        model: Device model name
+
+    """
 
     isn: str | None = None
     add: int | None = None
@@ -101,7 +110,7 @@ class GetInverterInfoItemResponse:
     tsw: str | None = None
     pac: int | None = None
     etd: int | None = None
-    eto: int | None = None
+    eto: int | None = None  # codespell:ignore eto
     err: int | None = None
     cmv: str | None = None
     mty: int | None = None
@@ -116,7 +125,13 @@ class GetInverterInfoItemResponse:
 
 @dataclass
 class GetInverterInfoResponse:
-    """Get inverter info response."""
+    """Get inverter info response.
+
+    Attributes:
+        inv: List of inverter info items
+        num: Number of inverters
+
+    """
 
     inv: list[GetInverterInfoItemResponse]
     num: int | None = None
@@ -126,26 +141,16 @@ class GetInverterInfoResponse:
 class GetMeterDataResponse:
     """Get meter data response model.
 
-    Attributes
-    ----------
-    flg : int
-        TBD ??
-    tim : str
-        Datetime in format YYYYMMDDHHMMSS
-    pac : int
-        AC real power [W]
-    itd : int
-        Input today
-    otd : int
-        Output today
-    iet : int
-        Input total
-    oet : int
-        Output total
-    mod : int
-        TBD ??
-    enb : int
-        TBD ??
+    Attributes:
+        flg: Meter status flag
+        tim: Timestamp of data
+        pac: Grid power in W (positive: import, negative: export)
+        itd: Today's imported energy in 0.01 kWh
+        otd: Today's exported energy in 0.01 kWh
+        iet: Total imported energy in 0.1 kWh
+        oet: Total exported energy in 0.1 kWh
+        mod: Meter operating mode
+        enb: Meter enabled status
 
     """
 
@@ -162,7 +167,27 @@ class GetMeterDataResponse:
 
 @dataclass
 class GetMeterInfoResponse:
-    """Get meter info response."""
+    """Get meter info response.
+
+    Attributes:
+        mod: Meter mode
+        enb: Meter enabled status
+        exp_m: Export mode
+        regulate: Regulation value
+        enb_PF: Power Factor enabled status
+        target_PF: Target Power Factor value
+        total_pac: Total active power in W
+        total_fac: Total frequency in 0.01 Hz
+        meter_pac: Meter power in W
+        sn: Meter serial number
+        manufactory: Manufacturer name
+        type: Meter type
+        name: Meter name
+        model: Meter model code
+        abs: Absolute value flag
+        offset: Offset value
+
+    """
 
     mod: int | None = None
     enb: int | None = None
@@ -186,24 +211,55 @@ class GetMeterInfoResponse:
 class GetBatteryDataResponse:
     """Get battery data response model.
 
-    Attributes
-    ----------
-    flg : int
-        TBD ??
-    tim : str
-        Datetime in format YYYYMMDDHHMMSS
-    vb : int
-        Battery voltage [V] (/100)
-    cb : int
-        Battery current [A] (/10)
-    pb : int
-        Power pattery [W]
-    tb : int
-        Temperature [dC]
-    soc : int
-        State of charge [%]
-    soh : int
-        State of health [%]
+    Attributes:
+        flg: Battery status flag
+        tim: Timestamp of data
+        ppv: PV power in W
+        etdpv: PV energy today in 0.1 kWh
+        etopv: PV energy total in 0.1 kWh
+        cst: Communication status code
+        bst: Battery status code
+        eb1: Battery error code group 1
+        eb2: Battery error code group 2
+        eb3: Battery error code group 3
+        eb4: Battery error code group 4
+        wb1: Battery warning code group 1
+        wb2: Battery warning code group 2
+        wb3: Battery warning code group 3
+        wb4: Battery warning code group 4
+        vb: Battery voltage in 0.01 V
+        cb: Battery current in 0.1 A
+        pb: Battery power in W
+        tb: Battery temperature in 0.1°C
+        soc: State of charge in %
+        soh: State of health in %
+        cli: Current limit for charging in 0.1 A
+        clo: Current limit for discharging in 0.1 A
+        ebi: Battery energy for charging in 0.1 kWh
+        ebo: Battery energy for discharging in 0.1 kWh
+        eaci: AC energy for charging in 0.1 kWh
+        eaco: AC energy for discharging in 0.1 kWh
+        vesp: EPS voltage in 0.1 V
+        cesp: EPS current in 0.1 A
+        fesp: EPS frequency in 0.01 Hz
+        pesp: EPS power in W
+        rpesp: EPS reactive power in VAr
+        etdesp: EPS energy today in 0.1 kWh
+        etoesp: EPS energy total in 0.1 kWh
+        charge_ac_td: AC charge today in 0.1 kWh
+        charge_ac_to: AC charge total in 0.1 kWh
+        vl1esp: EPS phase 1 voltage in 0.1 V
+        il1esp: EPS phase 1 current in 0.1 A
+        pac1esp: EPS phase 1 power in W
+        qac1esp: EPS phase 1 reactive power in VAr
+        vl2esp: EPS phase 2 voltage in 0.1 V
+        il2esp: EPS phase 2 current in 0.1 A
+        pac2esp: EPS phase 2 power in W
+        qac2esp: EPS phase 2 reactive power in VAr
+        vl3esp: EPS phase 3 voltage in 0.1 V
+        il3esp: EPS phase 3 current in 0.1 A
+        pac3esp: EPS phase 3 power in W
+        qac3esp: EPS phase 3 reactive power in VAr
 
     """
 
@@ -259,7 +315,30 @@ class GetBatteryDataResponse:
 
 @dataclass
 class GetBatteryInfoItemResponse:
-    """Get battery info item response."""
+    """Get battery info item response.
+
+    Attributes:
+        bid: Battery ID
+        devtype: Device type
+        manufactoty: Manufacturer name
+        partno: Part number
+        model1sn: Model 1 serial number
+        model2sn: Model 2 serial number
+        model3sn: Model 3 serial number
+        model4sn: Model 4 serial number
+        model5sn: Model 5 serial number
+        model6sn: Model 6 serial number
+        model7sn: Model 7 serial number
+        model8sn: Model 8 serial number
+        modeltotal: Total number of models
+        monomertotoal: Total number of monomers
+        monomerinmodel: Monomers per model
+        ratedvoltage: Rated voltage
+        capacity: Battery capacity
+        hardwarever: Hardware version
+        softwarever: Software version
+
+    """
 
     bid: int | None = None
     devtype: str | None = None
@@ -286,12 +365,19 @@ class GetBatteryInfoItemResponse:
 class GetBatteryInfoResponse:
     """Get battery data response model.
 
-    Attributes
-    ----------
-    charge_max : int
-        Max charge battery level [%]
-    discharge_max : int
-        Max discharge battery level [%]
+    Attributes:
+        type: Battery system type
+        mod_r: Battery work mode
+        battery: Battery detail information
+        isn: Battery serial number
+        stu_r: Status register
+        muf: Manufacturer code
+        mod: Battery model code
+        num: Number of batteries
+        fir_r: Firmware register
+        charging: Charging status
+        charge_max: Max state of charge in %
+        discharge_max: Min state of charge in %
 
     """
 
@@ -311,7 +397,19 @@ class GetBatteryInfoResponse:
 
 @dataclass
 class SetBatteryConfigValueRequest:
-    """Set battery config value request."""
+    """Set battery config value request.
+
+    Attributes:
+        type: Battery system type
+        mod_r: Battery work mode
+        sn: Battery serial number
+        discharge_max: Min state of charge in %
+        charge_max: Max state of charge in %
+        muf: Manufacturer code
+        mod: Battery model code
+        num: Number of batteries
+
+    """
 
     type: int
     mod_r: int
@@ -325,7 +423,14 @@ class SetBatteryConfigValueRequest:
 
 @dataclass
 class SetBatteryConfigRequest:
-    """Set battery config request."""
+    """Set battery config request.
+
+    Attributes:
+        value: Battery configuration values
+        device: Device type ID (4 for battery)
+        action: Action to perform (setbattery)
+
+    """
 
     value: SetBatteryConfigValueRequest
     device: int = 4
@@ -342,10 +447,16 @@ class SetScheduleRequest:
 
 @dataclass
 class BatteryWorkMode:
-    """Represent data for battery work mode."""
+    """Represent data for battery work mode.
+
+    Attributes:
+        name: Display name of the work mode
+        mod_r: Mode register value
+        type: Battery system type
+
+    """
 
     name: str
-
     mod_r: int
     type: int
 
@@ -686,6 +797,7 @@ class SolplanetApi:
         request = SetBatteryConfigRequest(value=value)
         await self.client.post("setting.cgi", request)
 
+
     async def get_schedule(self) -> dict:
         """Get battery schedule configuration."""
         _LOGGER.debug("Getting battery schedule")
@@ -737,6 +849,91 @@ class SolplanetApi:
         _LOGGER.debug("Setting raw schedule: %s", schedule)
         request = SetScheduleRequest(value=schedule)
         await self.client.post("setting.cgi", request)
+
+
+    async def modbus_read_holding_registers(
+        self,
+        data_type: DataType,
+        device_address: int,
+        register_address: int,
+        register_count: int = 1,
+    ) -> dict | int | str | None:
+        """Read modbus register."""
+        return await self._send_modbus(
+            frame=ModbusRtuFrameGenerator().generate_read_holding_register_frame(
+                device_id=device_address,
+                register_address=register_address,
+                register_length=register_count,
+            ),
+            data_type=data_type,
+        )
+
+    async def modbus_write_single_holding_register(
+        self,
+        data_type: DataType,
+        device_address: int,
+        register_address: int,
+        value: int,
+        dry_run: bool = False,
+    ) -> dict | int | str | None:
+        """Write modbus register."""
+        frame = ModbusRtuFrameGenerator().generate_write_single_holding_register_frame(
+            device_id=device_address,
+            register_address=register_address,
+            value=value,
+            data_type=data_type,
+        )
+        _LOGGER.debug(
+            "Generated frame for write single holding register (device_address: %s, data_type: %s, register_address: %s, value: %s, dry_run: %s): %s",
+            device_address,
+            data_type,
+            register_address,
+            value,
+            dry_run,
+            frame,
+        )
+        if dry_run:
+            return frame
+        return await self._send_modbus(frame=frame, data_type=data_type)
+
+    async def modbus_read_input_registers(
+        self,
+        data_type: DataType,
+        device_address: int,
+        register_address: int,
+        register_count: int = 1,
+    ) -> dict | int | str | None:
+        """Read modbus register."""
+        return await self._send_modbus(
+            frame=ModbusRtuFrameGenerator().generate_read_input_register_frame(
+                device_id=device_address,
+                register_address=register_address,
+                register_length=register_count,
+            ),
+            data_type=data_type,
+        )
+
+    async def _send_modbus(
+        self,
+        frame: str,
+        data_type: DataType,
+    ) -> dict | int | str | None:
+        """Send modbus frame."""
+        start_time = time.time()  # Start measuring time
+        response = await self.client.post("fdbg.cgi", {"data": frame})
+        end_time = time.time()  # End measuring time
+        elapsed_time = end_time - start_time
+
+        _LOGGER.debug("Modbus RTU request frame: %s", frame)
+        _LOGGER.debug("Modbus RTU response frame: %s", response)
+        _LOGGER.debug("Modbus RTU request time: %.2f seconds", elapsed_time)
+
+        data = ModbusRtuFrameGenerator().decode_response(
+            response_hex=response["data"], data_type=data_type
+        )
+        _LOGGER.debug("Modbus RTU response decoded: %s", data)
+
+        return data
 
     def _create_class_from_dict(self, cls, dict):
         return cls(**{k: v for k, v in dict.items() if k in signature(cls).parameters})

--- a/custom_components/solplanet/coordinator.py
+++ b/custom_components/solplanet/coordinator.py
@@ -118,12 +118,6 @@ class SolplanetDataUpdateCoordinator(DataUpdateCoordinator):
         await self.__api.set_battery_soc_max(sn, value)
         await self.async_refresh()
 
-    async def set_battery_schedule(self, sn: str, slots: dict[str, list[ScheduleSlot]], 
-                                 pin: int = 5000, pout: int = 5000) -> None:
-        """Set battery schedule."""
-        await self.__api.set_schedule(slots, pin, pout)
-        await self.async_refresh()
-
     async def set_battery_schedule_slots(self, sn: str, slots: dict[str, list[ScheduleSlot]]) -> None:
         """Set battery schedule slots."""
         _LOGGER.debug("Setting schedule slots for %s: %s", sn, slots)

--- a/custom_components/solplanet/entity.py
+++ b/custom_components/solplanet/entity.py
@@ -29,6 +29,7 @@ class SolplanetEntityDescription(EntityDescription):
     data_field_value_multiply: float | None = None
     data_field_value_mapper: abc.Callable[[Any], Any] | None = None
     unique_id_suffix: str | None = None
+    attributes_fn: abc.Callable[[Any], dict[str, Any]] | None = None
 
 
 class SolplanetEntity(CoordinatorEntity, Entity):
@@ -158,3 +159,19 @@ class SolplanetEntity(CoordinatorEntity, Entity):
                 },
             }
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return additional state attributes."""
+        if not self.entity_description.attributes_fn:
+            return None
+            
+        data = self.coordinator.data[
+            self.entity_description.data_field_device_type
+        ][self._isn][self.entity_description.data_field_data_type]
+
+        try:
+            return self.entity_description.attributes_fn(data)
+        except Exception as err:
+            _LOGGER.debug("Error getting attributes: %s", err)
+            return None

--- a/custom_components/solplanet/manifest.json
+++ b/custom_components/solplanet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/zbigniewmotyka/home-assistant-solplanet/issues",
   "requirements": [],
-  "version": "0.5.1"
+  "version": "0.6.0-beta1"
 }

--- a/custom_components/solplanet/modbus.py
+++ b/custom_components/solplanet/modbus.py
@@ -1,0 +1,280 @@
+"""Solplanet Modbus RTU frame generator and response decoder."""
+
+import contextlib
+import enum
+import struct
+
+
+class DataType(enum.Enum):
+    """Enum for supported data types in Modbus communications."""
+
+    B16 = "B16"  # Bit field (16-bit)
+    B32 = "B32"  # Bit field (32-bit)
+    S16 = "S16"  # Signed integer (16-bit)
+    U16 = "U16"  # Unsigned integer (16-bit)
+    S32 = "S32"  # Signed integer (32-bit)
+    U32 = "U32"  # Unsigned integer (32-bit)
+    E16 = "E16"  # Number code (16-bit)
+    STRING = "String"  # String type (16-bit, two 8-bit ASCII characters)
+
+
+class ModbusRtuFrameGenerator:
+    """A class to generate and decode Modbus RTU frames for various Modbus functions."""
+
+    # Definition of NaN values for different data types as class attribute
+    NAN_VALUES: dict[DataType, int] = {
+        DataType.B16: 0xFFFF,
+        DataType.B32: 0xFFFFFFFF,
+        DataType.S16: 0x8000,
+        DataType.U16: 0xFFFF,
+        DataType.S32: 0x80000000,
+        DataType.U32: 0xFFFFFFFF,
+        DataType.E16: 0xFFFF,
+        DataType.STRING: 0x0000,
+    }
+
+    # Value ranges for validation
+    VALUE_RANGES: dict[DataType, tuple[int, int]] = {
+        DataType.B16: (0, 0xFFFF),
+        DataType.U16: (0, 0xFFFF),
+        DataType.E16: (0, 0xFFFF),
+        DataType.B32: (0, 0xFFFFFFFF),
+        DataType.U32: (0, 0xFFFFFFFF),
+        DataType.S16: (-32768, 32767),
+        DataType.S32: (-2147483648, 2147483647),
+    }
+
+    def generate_read_holding_register_frame(
+        self, device_id: int, register_address: int, register_length: int
+    ) -> str:
+        """Generate Modbus RTU frame for Read Holding Register function (Function Code: 0x03)."""
+        register_offset = register_address - 40001
+        return self._generate_frame(device_id, 0x03, register_offset, register_length)
+
+    def generate_read_input_register_frame(
+        self, device_id: int, register_address: int, register_length: int
+    ) -> str:
+        """Generate Modbus RTU frame for Read Input Register function (Function Code: 0x04)."""
+        register_offset = register_address - 30001
+        return self._generate_frame(device_id, 0x04, register_offset, register_length)
+
+    def generate_write_single_holding_register_frame(
+        self, device_id: int, register_address: int, value, data_type: DataType
+    ) -> str:
+        """Generate Modbus RTU frame for Write Single Holding Register function (Function Code: 0x06)."""
+        register_offset = register_address - 40001
+        encoded_value = self.encode_request_data(value, data_type)
+        return self._generate_frame(device_id, 0x06, register_offset, encoded_value)
+
+    def _generate_frame(
+        self, device_id: int, function_code: int, register_offset: int, value: int
+    ) -> str:
+        """Generate Modbus RTU frame for the specified function code."""
+        if not (0 <= device_id <= 0xFF):
+            raise ValueError("Invalid device ID (0-255).")
+        if not (0 <= register_offset <= 0xFFFF):
+            raise ValueError("Invalid register offset (0-65535).")
+        if not (0 <= value <= 0xFFFF):
+            raise ValueError("Invalid value (0-65535).")
+
+        frame = struct.pack(
+            ">B B H H", device_id, function_code, register_offset, value
+        )
+        crc = self._calculate_crc(frame)
+        frame += struct.pack("<H", crc)  # Add CRC in little-endian order
+
+        return frame.hex()
+
+    def decode_response(
+        self, response_hex: str, data_type: DataType
+    ) -> dict | int | str | None:
+        """Decode Modbus RTU response based on function code and data type."""
+        response = bytes.fromhex(response_hex)
+
+        if len(response) < 5:
+            raise ValueError("Invalid response length.")
+
+        device_id, function_code = struct.unpack(">B B", response[:2])
+
+        # Use a more concise approach to function code routing
+        if function_code in (0x03, 0x04):
+            return self._decode_register_response(response, data_type)
+        if function_code == 0x06:
+            return self._decode_write_single_holding_register_response(response)
+        if function_code in [0x83, 0x84, 0x86]:
+            return self._decode_error_response(response)
+
+        raise ValueError("Unsupported function code in response.")
+
+    def _verify_crc(self, response: bytes) -> None:
+        """Verify CRC in the response."""
+        received_crc = struct.unpack("<H", response[-2:])[0]
+        calculated_crc = self._calculate_crc(response[:-2])
+
+        if received_crc != calculated_crc:
+            raise ValueError("CRC error: checksums do not match.")
+
+    def _decode_write_single_holding_register_response(
+        self, response: bytes
+    ) -> dict[str, int]:
+        """Decode Modbus RTU response for Write Single Holding Register function (Function Code: 0x06)."""
+        if len(response) != 8:
+            raise ValueError("Invalid response length.")
+
+        self._verify_crc(response)
+
+        device_id, function_code, register_address, data = struct.unpack(
+            ">B B H H", response[:6]
+        )
+
+        return {
+            "device_id": device_id,
+            "function_code": function_code,
+            "register_address": register_address,
+            "data": data,
+        }
+
+    def _decode_register_response(
+        self, response: bytes, data_type: DataType
+    ) -> int | str | None:
+        """Decode Modbus RTU response for Read Holding Register and Read Input Register functions."""
+        device_id, function_code, byte_count = struct.unpack(">B B B", response[:3])
+        data = response[3:-2]
+
+        self._verify_crc(response)
+
+        # Handle different data types based on length requirements
+        if data_type in [DataType.S32, DataType.U32, DataType.B32]:
+            if len(data) < 4:
+                raise ValueError(f"Insufficient data for type {data_type.value}")
+
+            # For 32-bit types we need 4 bytes (2 registers)
+            high_word = struct.unpack(">H", data[0:2])[0]
+            low_word = struct.unpack(">H", data[2:4])[0]
+
+            # Combine two 16-bit registers into one 32-bit value
+            raw_value = (high_word << 16) | low_word
+        else:
+            # For 16-bit types we need 2 bytes (1 register)
+            if len(data) < 2:
+                raise ValueError(f"Insufficient data for type {data_type.value}")
+
+            raw_value = struct.unpack(">H", data[0:2])[0]
+
+        return self._decode_value(raw_value, data_type)
+
+    def _decode_value(self, raw_value: int, data_type: DataType) -> int | str | None:
+        """Decode a single value based on data type."""
+        if raw_value == self.NAN_VALUES[data_type]:
+            return None
+
+        # Simplify handling of unsigned types that just return the raw value
+        if data_type in [
+            DataType.B16,
+            DataType.B32,
+            DataType.U16,
+            DataType.U32,
+            DataType.E16,
+        ]:
+            return raw_value
+
+        # Handle signed types
+        if data_type == DataType.S16:
+            return struct.unpack(">h", struct.pack(">H", raw_value))[0]
+        if data_type == DataType.S32:
+            return struct.unpack(">i", struct.pack(">I", raw_value))[0]
+
+        # Handle string type
+        if data_type == DataType.STRING:
+            high_byte = (raw_value >> 8) & 0xFF
+            low_byte = raw_value & 0xFF
+            # Simplified string handling
+            result = ""
+            if high_byte:
+                with contextlib.suppress(ValueError):
+                    result += chr(high_byte)
+            if low_byte:
+                with contextlib.suppress(ValueError):
+                    result += chr(low_byte)
+            return result
+
+        raise ValueError(f"Unsupported data type: {data_type}")
+
+    def _decode_error_response(self, response: bytes) -> dict[str, int]:
+        """Decode Modbus RTU error response."""
+        if len(response) != 5:
+            raise ValueError("Invalid error response length.")
+
+        self._verify_crc(response)
+
+        device_id, error_function_code, exception_code = struct.unpack(
+            ">B B B", response[:3]
+        )
+
+        return {
+            "device_id": device_id,
+            "error_function_code": error_function_code,
+            "exception_code": exception_code,
+        }
+
+    def _calculate_crc(self, data: bytes) -> int:
+        """Calculate CRC-16 checksum for Modbus RTU frame."""
+        crc = 0xFFFF
+        for byte in data:
+            crc ^= byte
+            for _ in range(8):
+                if crc & 0x0001:
+                    crc = (crc >> 1) ^ 0xA001
+                else:
+                    crc >>= 1
+        return crc
+
+    def encode_request_data(self, value, data_type: DataType) -> int:
+        """Encode value to appropriate format for Modbus RTU request."""
+        # Handle None values (NaN)
+        if value is None:
+            return self.NAN_VALUES[data_type]
+
+        # Validate value range for numeric types
+        if data_type in self.VALUE_RANGES:
+            min_val, max_val = self.VALUE_RANGES[data_type]
+            if not (min_val <= value <= max_val):
+                raise ValueError(
+                    f"Value for type {data_type.value} must be in range {min_val}-{max_val}"
+                )
+
+        # Process based on data type
+        if data_type in [
+            DataType.B16,
+            DataType.U16,
+            DataType.E16,
+            DataType.B32,
+            DataType.U32,
+        ]:
+            # All unsigned types just return the value
+            return value
+
+        if data_type == DataType.S16:
+            # Convert signed 16-bit to unsigned representation
+            return struct.unpack(">H", struct.pack(">h", value))[0]
+
+        if data_type == DataType.S32:
+            # Convert signed 32-bit to unsigned representation
+            return struct.unpack(">I", struct.pack(">i", value))[0]
+
+        if data_type == DataType.STRING:
+            if not isinstance(value, str) or len(value) > 2:
+                raise ValueError(
+                    f"Value for type {data_type.value} must be a string with a maximum length of 2 characters"
+                )
+
+            # Pad the string to a length of 2 (if it's shorter)
+            value = value.ljust(2, "\0")
+
+            # Convert two ASCII characters to a 16-bit value
+            high_byte = ord(value[0]) if value[0] else 0
+            low_byte = ord(value[1]) if value[1] else 0
+
+            return (high_byte << 8) | low_byte
+
+        raise ValueError(f"Unsupported data type: {data_type}")

--- a/custom_components/solplanet/number.py
+++ b/custom_components/solplanet/number.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import UnitOfPower, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -76,6 +76,32 @@ def create_battery_entites_description(
             native_step=1,
             native_unit_of_measurement=PERCENTAGE,
             callback=lambda value: coordinator.set_battery_soc_min(isn, int(value)),
+        ),
+        SolplanetNumberEntityDescription(
+            key=f"{isn}_schedule_pin",
+            name="Schedule Input Power",
+            icon="mdi:flash-triangle",
+            data_field_device_type=BATTERY_IDENTIFIER,
+            data_field_data_type="schedule",
+            data_field_path=["Pin"],  # Changed to use dict key
+            native_min_value=0,
+            native_max_value=10000,
+            native_step=100,
+            native_unit_of_measurement=UnitOfPower.WATT,
+            callback=lambda value: coordinator.set_battery_schedule_pin(isn, int(value)),
+        ),
+        SolplanetNumberEntityDescription(
+            key=f"{isn}_schedule_pout",
+            name="Schedule Output Power", 
+            icon="mdi:flash-triangle-outline",
+            data_field_device_type=BATTERY_IDENTIFIER,
+            data_field_data_type="schedule",
+            data_field_path=["Pout"],  # Changed to use dict key
+            native_min_value=0,
+            native_max_value=10000,
+            native_step=100,
+            native_unit_of_measurement=UnitOfPower.WATT,
+            callback=lambda value: coordinator.set_battery_schedule_pout(isn, int(value)),
         ),
     ]
 

--- a/custom_components/solplanet/services.py
+++ b/custom_components/solplanet/services.py
@@ -60,7 +60,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             
         processed = False
         for isn in isns:
-            for entry_id, data in hass.data[DOMAIN].items():
+            for data in hass.data[DOMAIN].values():
                 coordinator = data["coordinator"]
                 if isn in coordinator.data[BATTERY_IDENTIFIER]:
                     try:
@@ -114,7 +114,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             
         processed = False
         for isn in isns:
-            for entry_id, data in hass.data[DOMAIN].items():
+            for data in hass.data[DOMAIN].values():
                 coordinator = data["coordinator"]
                 if isn in coordinator.data[BATTERY_IDENTIFIER]:
                     # Get current schedule

--- a/custom_components/solplanet/services.py
+++ b/custom_components/solplanet/services.py
@@ -1,0 +1,162 @@
+"""Services for Solplanet integration."""
+from __future__ import annotations
+
+import logging
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+import voluptuous as vol
+
+from .client import ScheduleSlot, BatterySchedule
+from .const import DOMAIN, BATTERY_IDENTIFIER
+
+DAYS = ["Mon", "Tus", "Wen", "Thu", "Fri", "Sat", "Sun"]
+
+_LOGGER = logging.getLogger(__name__)
+
+async def get_isn_from_target(hass: HomeAssistant, target: dict) -> list[str]:
+    """Get ISNs from target entity_ids or device_ids."""
+    isns = set()
+    
+    # Handle entity_ids
+    if "entity_id" in target:
+        entity_reg = er.async_get(hass)
+        entity_ids = target["entity_id"] if isinstance(target["entity_id"], list) else [target["entity_id"]]
+            
+        for entity_id in entity_ids:
+            if entry := entity_reg.async_get(entity_id):
+                parts = entry.unique_id.split('_')
+                if len(parts) > 2:
+                    isns.add(parts[2])
+                
+    # Handle device_ids
+    if "device_id" in target:
+        device_reg = dr.async_get(hass)
+        device_ids = target["device_id"] if isinstance(target["device_id"], list) else [target["device_id"]]
+            
+        for device_id in device_ids:
+            if device := device_reg.async_get(device_id):
+                for identifier in device.identifiers:
+                    if identifier[0] == DOMAIN:
+                        isn = identifier[1].replace("battery_", "")
+                        isns.add(isn)
+                        break
+
+    return list(isns)
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services for Solplanet integration."""
+
+    async def set_schedule_slot(call: ServiceCall) -> None:
+        """Handle set_schedule_slot service."""
+        target = call.target if hasattr(call, 'target') else {}
+        if 'entity_id' in call.data:
+            target['entity_id'] = call.data['entity_id']
+        if 'device_id' in call.data:
+            target['device_id'] = call.data['device_id']
+
+        isns = await get_isn_from_target(hass, target)
+        if not isns:
+            raise vol.Invalid("No valid entities or devices found")
+            
+        processed = False
+        for isn in isns:
+            for entry_id, data in hass.data[DOMAIN].items():
+                coordinator = data["coordinator"]
+                if isn in coordinator.data[BATTERY_IDENTIFIER]:
+                    try:
+                        # Get current schedule
+                        current_schedule = coordinator.data[BATTERY_IDENTIFIER][isn]["schedule"]["slots"]
+
+                        # Check if we already have 6 slots for this day
+                        if call.data["day"] in current_schedule and len(current_schedule[call.data["day"]]) >= 6:
+                            raise vol.Invalid("Cannot add more than 6 slots per day")
+                        
+                        # Create new slot
+                        slot = ScheduleSlot.from_time(
+                            start=f"{call.data['start_hour']:02d}:{call.data['start_minute']:02d}",
+                            duration=call.data["duration"],
+                            mode=call.data["mode"]
+                        )
+                        
+                        # Get existing slots for the day
+                        new_slots = dict(current_schedule)
+                        day_slots = new_slots.get(call.data["day"], [])
+                        day_slots.append(slot)
+                        
+                        try:
+                            # This will validate max slots, overlaps, and midnight crossing
+                            ScheduleSlot.validate_slots(day_slots)
+                        except ValueError as err:
+                            raise vol.Invalid(str(err)) from err
+                            
+                        new_slots[call.data["day"]] = day_slots
+                        
+                        await coordinator.set_battery_schedule_slots(isn, new_slots)
+                        processed = True
+                        break
+                    except Exception as err:
+                        raise
+                    
+        if not processed:
+            raise vol.Invalid(f"No valid battery coordinator found for ISNs {isns}")
+
+    async def clear_schedule(call: ServiceCall) -> None:
+        """Handle clear_schedule service."""
+        target = call.target if hasattr(call, 'target') else {}
+        if 'entity_id' in call.data:
+            target['entity_id'] = call.data['entity_id']
+        if 'device_id' in call.data:
+            target['device_id'] = call.data['device_id']
+
+        isns = await get_isn_from_target(hass, target)
+        if not isns:
+            raise vol.Invalid("No valid entities or devices found")
+            
+        processed = False
+        for isn in isns:
+            for entry_id, data in hass.data[DOMAIN].items():
+                coordinator = data["coordinator"]
+                if isn in coordinator.data[BATTERY_IDENTIFIER]:
+                    # Get current schedule
+                    current_schedule = coordinator.data[BATTERY_IDENTIFIER][isn]["schedule"]["slots"]
+                    
+                    if call.data["day"] == "all":
+                        new_slots = {day: [] for day in BatterySchedule.DAYS}
+                    else:
+                        # Keep other days unchanged
+                        new_slots = dict(current_schedule)
+                        new_slots[call.data["day"]] = []
+                    
+                    await coordinator.set_battery_schedule_slots(isn, new_slots)
+                    processed = True
+                    break
+                    
+        if not processed:
+            raise vol.Invalid(f"No valid battery coordinator found for ISNs {isns}")
+
+    # Service schemas stay the same
+    hass.services.async_register(
+        DOMAIN, 
+        "set_schedule_slot", 
+        set_schedule_slot, 
+        schema=vol.Schema({
+            vol.Optional("entity_id"): vol.Any(str, [str]),
+            vol.Optional("device_id"): vol.Any(str, [str]),
+            vol.Required("day"): vol.In(BatterySchedule.DAYS),
+            vol.Required("start_hour"): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+            vol.Required("start_minute"): vol.In([0, 30]),
+            vol.Required("duration"): vol.All(vol.Coerce(int), vol.Range(min=1, max=4)),
+            vol.Required("mode"): vol.In(["charge", "discharge"])
+        })
+    )
+
+    hass.services.async_register(
+        DOMAIN, 
+        "clear_schedule", 
+        clear_schedule, 
+        schema=vol.Schema({
+            vol.Optional("entity_id"): vol.Any(str, [str]),
+            vol.Optional("device_id"): vol.Any(str, [str]),
+            vol.Required("day"): vol.In(["all"] + BatterySchedule.DAYS)
+        })
+    )

--- a/custom_components/solplanet/services.yaml
+++ b/custom_components/solplanet/services.yaml
@@ -35,10 +35,11 @@ set_schedule_slot:
       description: Minute to start (0 or 30)
       required: true
       selector:
-        select:
-          options:
-            - 0
-            - 30
+        number:
+          min: 0
+          max: 30
+          step: 30
+          mode: box
     duration:
       name: Duration
       description: Duration in hours (1-4)

--- a/custom_components/solplanet/services.yaml
+++ b/custom_components/solplanet/services.yaml
@@ -1,0 +1,84 @@
+set_schedule_slot:
+  name: Set Schedule Slot
+  description: Set a charging/discharging schedule slot for a specific battery
+  target:
+    entity:
+      integration: solplanet
+      domain: binary_sensor
+  fields:
+    day:
+      name: Day
+      description: Day of the week
+      required: true
+      selector:
+        select:
+          options:
+            - "Mon"
+            - "Tus"
+            - "Wen"
+            - "Thu"
+            - "Fri"
+            - "Sat"
+            - "Sun"
+    start_hour:
+      name: Start Hour
+      description: Hour to start (0-23)
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 23
+          step: 1
+          mode: box
+    start_minute:
+      name: Start Minute
+      description: Minute to start (0 or 30)
+      required: true
+      selector:
+        select:
+          options:
+            - 0
+            - 30
+    duration:
+      name: Duration
+      description: Duration in hours (1-4)
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 4
+          step: 1
+          mode: box
+    mode:
+      name: Mode
+      description: Charge or discharge mode
+      required: true
+      selector:
+        select:
+          options:
+            - "charge"
+            - "discharge"
+
+clear_schedule:
+  name: Clear Schedule
+  description: Clear schedule for specific battery
+  target:
+    entity:
+      integration: solplanet
+      domain: binary_sensor
+  fields:
+    day:
+      name: Day
+      description: Day to clear or 'all' for all days
+      required: true
+      selector:
+        select:
+          options:
+            - "all"
+            - "Mon"
+            - "Tus"
+            - "Wen"
+            - "Thu"
+            - "Fri"
+            - "Sat"
+            - "Sun"

--- a/custom_components/solplanet/services.yaml
+++ b/custom_components/solplanet/services.yaml
@@ -82,3 +82,64 @@ clear_schedule:
             - "Fri"
             - "Sat"
             - "Sun"
+
+modbus_write_single_holding_register:
+  name: Modbus write single holding register
+  description: Write a single holding register to a modbus device.
+  fields:
+    device_address:
+      name: Device address
+      description: The modbus device address.
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 255
+          step: 1
+          mode: box
+    register_address:
+      name: Register address
+      description: The modbus register address to write to (full address, not offset).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 65535
+          step: 1
+          mode: box
+    data_type:
+      name: Data type
+      description: The type of data to write.
+      required: true
+      selector:
+        select:
+          options:
+            - label: "B16 - Bit field 16-bit"
+              value: "B16"
+            - label: "B32 - Bit field 32-bit"
+              value: "B32"
+            - label: "S16 - Signed 16-bit Integer"
+              value: "S16"
+            - label: "U16 - Unsigned 16-bit Integer"
+              value: "U16"
+            - label: "S32 - Signed 32-bit Integer"
+              value: "S32"
+            - label: "U32 - Unsigned 32-bit Integer"
+              value: "U32"
+            - label: "E16 - Number code 16-bit"
+              value: "E16"
+    value:
+      name: Data value
+      description: The value to write to the register.
+      required: true
+      selector:
+        number:
+          step: 1
+          mode: box
+    dry_run:
+      name: Dry run
+      description: If true, rtu frame will be generated and logged but not sent.
+      required: true
+      default: false
+      selector:
+        boolean: {}


### PR DESCRIPTION
# Battery Schedule Management Feature

Added support for managing battery charge/discharge schedules through Home Assistant services.

Key features:
- Added two services: `set_schedule_slot` and `clear_schedule`
- Support up to 6 slots per day with validation
- Prevent overlapping schedules and crossing midnight
- Added schedule status binary sensor with formatted schedule view in attributes
- Maintain Pin/Pout power settings when modifying schedules

Schedule constraints:
- Each day can have up to 6 slots
- Slots must start at :00 or :30
- Duration is 1-4 hours
- Cannot cross midnight (e.g. at 23:00 max duration is 1h)
- Cannot overlap with other slots

Example schedule slot configuration:
```yaml
service: solplanet.set_schedule_slot
target:
  entity_id: binary_sensor.solplanet_battery_xyz123_schedule_active
data:
  day: "Mon"
  start_hour: 14
  start_minute: 30
  duration: 2
  mode: "charge"
```

```yaml
service: solplanet.clear_schedule
target:
  entity_id: binary_sensor.solplanet_battery_xyz123_schedule_active
data:
  day: "all"  # or specific day
```

The schedule status can be viewed in the binary sensor attributes, showing both raw and human-readable formats.