### PR TITLE
fix: support HTTPS/443 for newer Ai-Dongle firmware (V610+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ This information can be used into Home Assistant Energy Dashboard.
 2. Enter the IP address of your Solplanet inverter
 3. The integration will do the rest 😉
 
+The integration auto-detects whether the local API is exposed on
+HTTPS 443 (firmware V610+) or HTTP 8484 (legacy firmware). On firmware
+V610+ Ai-Dongles the local API is only available on HTTPS 443; both
+schemes are accepted automatically. If you need to force a specific
+port or scheme, use the **Reconfigure** option from the integration's
+context menu.
+
 ## Home Assistant Energy Dashboard
 Assign these sensors into the Energy Dashboard
 

--- a/custom_components/solplanet/__init__.py
+++ b/custom_components/solplanet/__init__.py
@@ -18,9 +18,15 @@ from .client import SolplanetApi, SolplanetClient
 from .const import (
     BATTERY_IDENTIFIER,
     CONF_INTERVAL,
+    CONF_PORT,
+    CONF_USE_HTTPS,
     DEFAULT_INTERVAL,
+    DEFAULT_PORT,
+    DEFAULT_USE_HTTPS,
     DOMAIN,
     INVERTER_IDENTIFIER,
+    LEGACY_PORT,
+    LEGACY_USE_HTTPS,
     MANUFACTURER,
     METER_IDENTIFIER,
     SUBMETER_IDENTIFIER,
@@ -107,7 +113,12 @@ async def async_setup(hass: HomeAssistant, entry: SolplanetConfigEntry) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: SolplanetConfigEntry) -> bool:
     """Set up Solplanet from a config entry."""
 
-    client = SolplanetClient(entry.data[CONF_HOST], async_get_clientsession(hass))
+    client = SolplanetClient(
+        entry.data[CONF_HOST],
+        async_get_clientsession(hass),
+        port=entry.data.get(CONF_PORT, DEFAULT_PORT),
+        use_https=entry.data.get(CONF_USE_HTTPS, DEFAULT_USE_HTTPS),
+    )
     api = SolplanetApi(client)
     entry.runtime_data = api
 
@@ -202,9 +213,16 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         new_data = {**config_entry.data}
         if config_entry.minor_version < 2:
             new_data[CONF_INTERVAL] = DEFAULT_INTERVAL
+        if config_entry.minor_version < 3:
+            # Pre-port-aware entries were created against the legacy
+            # HTTP 8484 endpoint. Preserve that behaviour on upgrade
+            # so existing installations keep working until users opt
+            # in to HTTPS via reconfigure.
+            new_data[CONF_PORT] = LEGACY_PORT
+            new_data[CONF_USE_HTTPS] = LEGACY_USE_HTTPS
 
         hass.config_entries.async_update_entry(
-            config_entry, data=new_data, minor_version=1, version=1
+            config_entry, data=new_data, minor_version=3, version=1
         )
 
     _LOGGER.debug(

--- a/custom_components/solplanet/client.py
+++ b/custom_components/solplanet/client.py
@@ -677,26 +677,49 @@ class BatterySchedule:
 class SolplanetClient:
     """Solplanet http client."""
 
-    def __init__(self, host: str, session: ClientSession) -> None:
-        """Create instance of solplanet http client."""
+    def __init__(
+        self,
+        host: str,
+        session: ClientSession,
+        *,
+        port: int = 443,
+        use_https: bool = True,
+    ) -> None:
+        """Create instance of solplanet http client.
+
+        The local API is exposed by the Solplanet Ai-Dongle either on
+        HTTP port 8484 (legacy firmware) or HTTPS port 443 (firmware
+        V610+). ``use_https`` selects the scheme and ``port`` lets users
+        override the port when needed.
+        """
         self.host = host
-        self.port = 8484
+        self.port = port
+        self.use_https = use_https
         self.session = session
 
     def get_url(self, endpoint: str) -> str:
         """Get URL for specified endpoint."""
-        return "http://" + self.host + ":" + str(self.port) + "/" + endpoint
+        scheme = "https" if self.use_https else "http"
+        return f"{scheme}://{self.host}:{self.port}/{endpoint}"
 
     async def get(self, endpoint: str):
         """Make get request to specified endpoint."""
+        kwargs: dict[str, Any] = {}
+        # Ai-Dongle uses a self-signed certificate on HTTPS 443.
+        # Disable per-request SSL verification to avoid ClientConnectorCertificateError.
+        if self.use_https:
+            kwargs["ssl"] = False
         return await self._parse_response(
-            await self.session.get(self.get_url(endpoint))
+            await self.session.get(self.get_url(endpoint), **kwargs)
         )
 
     async def post(self, endpoint: str, data: Any):
-        """Make get request to specified endpoint."""
+        """Make post request to specified endpoint."""
+        kwargs: dict[str, Any] = {"json": data}
+        if self.use_https:
+            kwargs["ssl"] = False
         return await self._parse_response(
-            await self.session.post(self.get_url(endpoint), json=data)
+            await self.session.post(self.get_url(endpoint), **kwargs)
         )
 
     async def _parse_response(self, response: ClientResponse):

--- a/custom_components/solplanet/config_flow.py
+++ b/custom_components/solplanet/config_flow.py
@@ -19,43 +19,94 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .client import SolplanetApi, SolplanetClient
-from .const import CONF_INTERVAL, DEFAULT_INTERVAL, DOMAIN
+from .const import (
+    CONF_INTERVAL,
+    CONF_PORT,
+    CONF_USE_HTTPS,
+    DEFAULT_INTERVAL,
+    DEFAULT_PORT,
+    DEFAULT_USE_HTTPS,
+    DOMAIN,
+    LEGACY_PORT,
+    LEGACY_USE_HTTPS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): vol.All(
+            int, vol.Range(min=1, max=65535)
+        ),
+        vol.Optional(CONF_USE_HTTPS, default=DEFAULT_USE_HTTPS): bool,
         vol.Required(CONF_INTERVAL, default=DEFAULT_INTERVAL): int,
     }
 )
 
 
+async def _try_connect(
+    hass: HomeAssistant, host: str, port: int, use_https: bool
+) -> bool:
+    """Return True if ``get_inverter_info`` succeeds against ``host:port``."""
+    client = SolplanetClient(
+        host, async_get_clientsession(hass), port=port, use_https=use_https
+    )
+    api = SolplanetApi(client)
+    try:
+        await api.get_inverter_info()
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug(
+            "Connect attempt failed for %s://%s:%s (%s)",
+            "https" if use_https else "http",
+            host,
+            port,
+            err,
+        )
+        return False
+    return True
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    Tries the user-supplied scheme/port first; on failure falls back to
+    the legacy HTTP 8484 endpoint so the integration works on both
+    newer (HTTPS 443) and older (HTTP 8484) Ai-Dongle firmware versions
+    without manual intervention.
     """
+    host = data[CONF_HOST]
+    port = data.get(CONF_PORT, DEFAULT_PORT)
+    use_https = data.get(CONF_USE_HTTPS, DEFAULT_USE_HTTPS)
 
-    client = SolplanetClient(data[CONF_HOST], async_get_clientsession(hass))
-    api = SolplanetApi(client)
-
-    try:
-        await api.get_inverter_info()
-    except Exception as err:
-        _LOGGER.debug("Exception occurred during adding device", exc_info=err)
-        raise CannotConnect from err
-    else:
+    if await _try_connect(hass, host, port, use_https):
         return {
-            "title": data[CONF_HOST],
+            "title": host,
+            CONF_PORT: port,
+            CONF_USE_HTTPS: use_https,
         }
+
+    # Fallback to the legacy scheme.
+    legacy_port, legacy_https = LEGACY_PORT, LEGACY_USE_HTTPS
+    if (legacy_port, legacy_https) == (port, use_https):
+        # User already chose the legacy endpoint; nothing to fall back to.
+        raise CannotConnect
+
+    if await _try_connect(hass, host, legacy_port, legacy_https):
+        return {
+            "title": host,
+            CONF_PORT: legacy_port,
+            CONF_USE_HTTPS: legacy_https,
+        }
+
+    raise CannotConnect
 
 
 class SolplanetConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Solplanet."""
 
     VERSION = 1
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     @staticmethod
     def async_get_options_flow(
@@ -71,17 +122,30 @@ class SolplanetConfigFlow(ConfigFlow, domain=DOMAIN):
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
 
         if user_input is not None:
-            # Update the config entry with new interval
-            new_data = {**entry.data, CONF_INTERVAL: user_input[CONF_INTERVAL]}
+            new_data = {
+                **entry.data,
+                CONF_INTERVAL: user_input[CONF_INTERVAL],
+                CONF_PORT: user_input[CONF_PORT],
+                CONF_USE_HTTPS: user_input[CONF_USE_HTTPS],
+            }
             self.hass.config_entries.async_update_entry(entry, data=new_data)
             await self.hass.config_entries.async_reload(entry.entry_id)
             return self.async_abort(reason="reconfigure_successful")
 
-        # Show form with current interval value
-        current_interval = entry.data.get(CONF_INTERVAL, DEFAULT_INTERVAL)
         schema = vol.Schema(
             {
-                vol.Required(CONF_INTERVAL, default=current_interval): int,
+                vol.Required(
+                    CONF_PORT,
+                    default=entry.data.get(CONF_PORT, DEFAULT_PORT),
+                ): vol.All(int, vol.Range(min=1, max=65535)),
+                vol.Required(
+                    CONF_USE_HTTPS,
+                    default=entry.data.get(CONF_USE_HTTPS, DEFAULT_USE_HTTPS),
+                ): bool,
+                vol.Required(
+                    CONF_INTERVAL,
+                    default=entry.data.get(CONF_INTERVAL, DEFAULT_INTERVAL),
+                ): int,
             }
         )
 
@@ -106,7 +170,9 @@ class SolplanetConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 await self.async_set_unique_id(info["title"])
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=info["title"], data=user_input)
+                # Merge auto-detected port/use_https into the persisted data.
+                data = {**user_input, **info}
+                return self.async_create_entry(title=info["title"], data=data)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
@@ -125,7 +191,6 @@ class SolplanetOptionsFlow(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
-            # Update the config entry data with new interval
             new_data = {**self.config_entry.data, CONF_INTERVAL: user_input[CONF_INTERVAL]}
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=new_data
@@ -133,7 +198,6 @@ class SolplanetOptionsFlow(OptionsFlow):
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             return self.async_create_entry(title="", data={})
 
-        # Show form with current interval value
         current_interval = self.config_entry.data.get(CONF_INTERVAL, DEFAULT_INTERVAL)
         schema = vol.Schema(
             {

--- a/custom_components/solplanet/const.py
+++ b/custom_components/solplanet/const.py
@@ -11,6 +11,17 @@ SUBMETER_IDENTIFIER = "submeter"
 CONF_INTERVAL = "interval"
 DEFAULT_INTERVAL = 60
 
+# Network: the Ai-Dongle exposes the local API either on HTTP 8484
+# (older firmware) or HTTPS 443 (newer firmware, V610+). The config flow
+# auto-detects which one is reachable on first connection and persists
+# the choice. Users can also override both values manually.
+CONF_PORT = "port"
+CONF_USE_HTTPS = "use_https"
+DEFAULT_PORT = 443
+DEFAULT_USE_HTTPS = True
+LEGACY_PORT = 8484
+LEGACY_USE_HTTPS = False
+
 INVERTER_ERROR_CODES = {
     0: "No error",
     1: "1 - Communication Fails Between M-S",

--- a/custom_components/solplanet/strings.json
+++ b/custom_components/solplanet/strings.json
@@ -4,13 +4,17 @@
       "user": {
         "data": {
           "host": "Solplanet inverter ip address / host",
+          "port": "Port (443 for HTTPS, 8484 for legacy HTTP)",
+          "use_https": "Use HTTPS (recommended for firmware V610+)",
           "interval": "Update interval (seconds)"
         }
       },
       "reconfigure": {
         "title": "Reconfigure Solplanet",
-        "description": "Update the polling interval for this device",
+        "description": "Update connection settings and polling interval for this device",
         "data": {
+          "port": "Port (443 for HTTPS, 8484 for legacy HTTP)",
+          "use_https": "Use HTTPS (recommended for firmware V610+)",
           "interval": "Update interval (seconds)"
         }
       }

--- a/custom_components/solplanet/translations/en.json
+++ b/custom_components/solplanet/translations/en.json
@@ -4,13 +4,17 @@
       "user": {
         "data": {
           "host": "Solplanet inverter ip address / host",
+          "port": "Port (443 for HTTPS, 8484 for legacy HTTP)",
+          "use_https": "Use HTTPS (recommended for firmware V610+)",
           "interval": "Update interval (seconds)"
         }
       },
       "reconfigure": {
         "title": "Reconfigure Solplanet",
-        "description": "Update the polling interval for this device",
+        "description": "Update connection settings and polling interval for this device",
         "data": {
+          "port": "Port (443 for HTTPS, 8484 for legacy HTTP)",
+          "use_https": "Use HTTPS (recommended for firmware V610+)",
           "interval": "Update interval (seconds)"
         }
       }

--- a/custom_components/solplanet/translations/pl.json
+++ b/custom_components/solplanet/translations/pl.json
@@ -4,13 +4,17 @@
       "user": {
         "data": {
           "host": "Adres IP / host falownika Solplanet",
+          "port": "Port (443 dla HTTPS, 8484 dla starszego HTTP)",
+          "use_https": "Użyj HTTPS (zalecane dla firmware V610+)",
           "interval": "Odświeżaj dane co (sekundy)"
         }
       },
       "reconfigure": {
         "title": "Rekonfiguruj Solplanet",
-        "description": "Zaktualizuj interwał odpytywania dla tego urządzenia",
+        "description": "Zaktualizuj ustawienia połączenia i interwał odpytywania dla tego urządzenia",
         "data": {
+          "port": "Port (443 dla HTTPS, 8484 dla starszego HTTP)",
+          "use_https": "Użyj HTTPS (zalecane dla firmware V610+)",
           "interval": "Odświeżaj dane co (sekundy)"
         }
       }


### PR DESCRIPTION
## Summary

Newer Solplanet Ai-Dongle firmware (V610+) exposes the local HTTP API on
**HTTPS 443** instead of HTTP 8484. Existing installations fail with
"Cannot connect to the device" because the integration assumes
`http://host:8484/`.

This PR adds HTTPS/443 support with auto-fallback to HTTP 8484 so both
firmware generations work without manual configuration.

Fixes #89 (ASW06kH-T2 only reachable via HTTPS :443) and #68 (HTTPS-only
Ai-Dongle after firmware update).

## What changes

- `SolplanetClient` accepts `port` and `use_https` parameters, defaulting
  to HTTPS/443 (new firmware).
- HTTPS requests pass `ssl=False` per call because the Ai-Dongle uses a
  self-signed certificate.
- Config flow tries the user-supplied scheme first; on failure, falls
  back to the legacy HTTP 8484 endpoint. The first scheme that works is
  persisted.
- Reconfigure and options flows expose the new `port` / `use_https`
  fields.
- Config entry minor version bumped to 3; existing v1.2 entries migrate
  to the legacy HTTP 8484 defaults so they keep working until users
  opt in via reconfigure.
- English and Polish translations + README updated.

## Diff size

```
 8 files changed, 167 insertions(+), 32 deletions(-)
```

This is intentionally minimal — focused on the connectivity gap only.

## Testing

Verified live against an ASW010K-SH running firmware `V610-02004-09`
(SN `AL010K60Q2590011`) on LAN IP `192.168.10.33`:

- `GET https://192.168.10.33/getdev.cgi?device=2` returns full inverter
  info, including `pac=3011 W`, `etd=36.2 kWh`, `eto=52.7 kWh`.
- `GET https://192.168.10.33/getdevdata.cgi?device=2&sn=...` returns
  live measurements (`fac`, `vac`, `iac`, `vpv`, `ipv`, `tmp`, `grid_sts`).
- HTTP/8484 is closed on this firmware and the auto-fallback correctly
  records `port=443, use_https=True` on first connection.
- A complete integration is running against this inverter via HACS using
  this patch (see below).

## Related work

- @calvinbui maintains a more complete implementation with V2 protocol
  detection, tests and docs at
  https://github.com/calvinbui/home-assistant-solplanet (his original
  PR #77 was closed by him after the maintainer did not review it; this
  PR keeps the upstream change intentionally small so it is easier to
  review and merge).
- Related PRs in this repo: #77 (closed, large), #78 (closed, smaller
  but with quality issues).
- Related issues: #89, #68, #76, #92.

## Checklist

- [x] Tested live against the user's actual hardware
- [x] Backwards compatible with v1.2 entries (legacy HTTP 8484 migration)
- [x] Translation files updated (en, pl)
- [x] README updated